### PR TITLE
APL-732 Bluetoothリトライ処理のエラーハンドリング追加

### DIFF
--- a/sdk/src/main/java/com/spacer/sdk/data/SPRError.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/SPRError.kt
@@ -30,6 +30,12 @@ data class SPRError(
         val CBCharacteristicNotFound = SPRError("E22011002", "peripheral characteristic is not found")
         val CBReadingCharacteristicFailed = SPRError("E22011003", "peripheral reading characteristic failed")
         val CBWritingCharacteristicFailed = SPRError("E22011004", "peripheral writing characteristic failed")
-        val CBConnectDuringTimeout = SPRError("E22011005", "timeout occurred during connection processing")
+
+        val CBConnectStartTimeout = SPRError("E21011201", "timeout occurred while connecting to peripheral")
+        val CBConnectDiscoverTimeout = SPRError("E21011202", "timeout occurred while discovering characteristic")
+        val CBConnectReadTimeoutBeforeWrite = SPRError("E21011203", "timeout occurred while reading the value of the characteristic before write")
+        val CBConnectReadTimeoutAfterWrite = SPRError("E21011204", "timeout occurred while reading the value of the characteristic after write")
+        val CBConnectWriteTimeout = SPRError("E21011205", "timeout occurred while writing value to characteristic")
+        val CBConnectDuringTimeout = SPRError("E21011206", "timeout occurred during connection processing")
     }
 }

--- a/sdk/src/main/java/com/spacer/sdk/data/SPRError.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/SPRError.kt
@@ -31,11 +31,11 @@ data class SPRError(
         val CBReadingCharacteristicFailed = SPRError("E22011003", "peripheral reading characteristic failed")
         val CBWritingCharacteristicFailed = SPRError("E22011004", "peripheral writing characteristic failed")
 
-        val CBConnectStartTimeout = SPRError("E21011201", "timeout occurred while connecting to peripheral")
-        val CBConnectDiscoverTimeout = SPRError("E21011202", "timeout occurred while discovering characteristic")
-        val CBConnectReadTimeoutBeforeWrite = SPRError("E21011203", "timeout occurred while reading the value of the characteristic before write")
-        val CBConnectReadTimeoutAfterWrite = SPRError("E21011204", "timeout occurred while reading the value of the characteristic after write")
-        val CBConnectWriteTimeout = SPRError("E21011205", "timeout occurred while writing value to characteristic")
-        val CBConnectDuringTimeout = SPRError("E21011206", "timeout occurred during connection processing")
+        val CBConnectStartTimeout = SPRError("E22011201", "timeout occurred while connecting to peripheral")
+        val CBConnectDiscoverTimeout = SPRError("E22011202", "timeout occurred while discovering characteristic")
+        val CBConnectReadTimeoutBeforeWrite = SPRError("E22011203", "timeout occurred while reading the value of the characteristic before write")
+        val CBConnectReadTimeoutAfterWrite = SPRError("E22011204", "timeout occurred while reading the value of the characteristic after write")
+        val CBConnectWriteTimeout = SPRError("E22011205", "timeout occurred while writing value to characteristic")
+        val CBConnectDuringTimeout = SPRError("E22011206", "timeout occurred during connection processing")
     }
 }

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattService.kt
@@ -33,7 +33,6 @@ open class CBLockerGattService {
             gattCallback.onFailure(error)
         } else {
             isRetry = true
-            logd("########## connectRetryCnt: $connectRetryCnt")
             connectRemoteDevice()
         }
     }
@@ -83,7 +82,6 @@ open class CBLockerGattService {
 
         override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
             timeout.discover.clear()
-            logd("onServicesDiscovered: $status")
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 return gatt.fail(SPRError.CBServiceNotFound)
             }
@@ -196,7 +194,6 @@ open class CBLockerGattService {
                 isRetry = true
                 disconnect()
                 close()
-                logd("########## connectRetryCnt: $connectRetryCnt")
                 connectRemoteDevice()
             }
         }

--- a/sdk/src/main/java/com/spacer/sdk/values/cbLocker/CBLockerConst.kt
+++ b/sdk/src/main/java/com/spacer/sdk/values/cbLocker/CBLockerConst.kt
@@ -7,7 +7,11 @@ class CBLockerConst {
     companion object {
         const val DEVICE_PUT_PREFIX = "543214723567xxxrw"
         const val DEVICE_TAKE_PREFIX = "543214723567xxxw"
-        const val ConnectMills: Long = 5000
+        const val StartTimeoutSeconds: Long  = 5000
+        const val DiscoverTimeoutSeconds: Long  = 5000
+        const val ReadTimeoutSeconds: Long  = 5000
+        const val WriteTimeoutSeconds: Long  = 5000
+        const val DuringTimeoutSeconds: Long  = 60000
 
         val ScanMills = SPR.config.scanMills
         val MaxRetryNum = SPR.config.maxRetryNum

--- a/sdk/src/main/java/com/spacer/sdk/values/cbLocker/CBLockerTimeout.kt
+++ b/sdk/src/main/java/com/spacer/sdk/values/cbLocker/CBLockerTimeout.kt
@@ -1,0 +1,35 @@
+package com.spacer.sdk.values.cbLocker
+
+import android.os.Handler
+import android.os.Looper
+import com.spacer.sdk.data.ICallback
+import com.spacer.sdk.data.SPRError
+
+class CBLockerTimeout(private val seconds: Long, private val timeoutAction: () -> Unit) {
+    private val handler = Handler(Looper.getMainLooper())
+    private var runnable: Runnable? = null
+
+    fun set() {
+        runnable = Runnable {
+            timeoutAction.invoke()
+        }
+        handler.postDelayed(runnable!!, seconds)
+    }
+
+    fun clear() {
+        runnable?.let { handler.removeCallbacks(it) }
+    }
+}
+
+class CBLockerConnectTimeouts(retryOrFailure: (SPRError) -> Unit) : ICallback {
+    var start = CBLockerTimeout(CBLockerConst.StartTimeoutSeconds) { retryOrFailure(SPRError.CBConnectStartTimeout) }
+    var discover = CBLockerTimeout(CBLockerConst.DiscoverTimeoutSeconds) { retryOrFailure(SPRError.CBConnectDiscoverTimeout) }
+    var readBeforeWrite = CBLockerTimeout(CBLockerConst.ReadTimeoutSeconds) { retryOrFailure(SPRError.CBConnectReadTimeoutBeforeWrite) }
+    var readAfterWrite = CBLockerTimeout(CBLockerConst.ReadTimeoutSeconds) { retryOrFailure(SPRError.CBConnectReadTimeoutAfterWrite) }
+    var write = CBLockerTimeout(CBLockerConst.WriteTimeoutSeconds) { retryOrFailure(SPRError.CBConnectWriteTimeout) }
+    var during = CBLockerTimeout(CBLockerConst.DuringTimeoutSeconds) { retryOrFailure(SPRError.CBConnectDuringTimeout) }
+
+    fun clearAll() {
+        arrayOf(start, discover, readBeforeWrite, readAfterWrite, write, during).forEach { timeout -> timeout.clear() }
+    }
+}


### PR DESCRIPTION
**修正内容**
・Bluetooth接続時のタイムアウト処理を処理ごとに行うように対応

**テスト**
・施錠、解錠、再解錠できること
・Bluetooth,API接続にて失敗した場合リトライすること
・Bluetooth接続時に処理ごとにタイムアウトされること