### PR TITLE
APL-839 リトライ箇所の修正と排他制御を追加

### DIFF
--- a/sdk/src/main/java/com/spacer/sdk/data/api/APIClient.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/APIClient.kt
@@ -1,8 +1,6 @@
 package com.spacer.sdk.data.api
 
 import android.os.Build
-import com.spacer.sdk.data.extensions.LoggerExtensions.logd
-import com.spacer.sdk.values.cbLocker.CBLockerConst
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -21,16 +19,7 @@ class APIClient {
                 .addHeader("Accept", "application/json")
                 .addHeader("User-Agent", userAgent)
                 .build()
-            var response = chain.proceed(request)
-
-            var retryCount = 0
-            while (!response.isSuccessful && retryCount < CBLockerConst.MaxRetryNum){
-                retryCount++
-
-                response.close()
-                response = chain.proceed(request)
-            }
-            return@Interceptor response
+            return@Interceptor chain.proceed(request)
         }
 
     private val userAgent: String

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/CBLockerService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/CBLockerService.kt
@@ -9,32 +9,87 @@ import com.spacer.sdk.models.sprLocker.SPRLockerModel
 import com.spacer.sdk.services.cbLocker.scan.CBLockerScanConnectService
 import com.spacer.sdk.services.cbLocker.scan.CBLockerScanListService
 import com.spacer.sdk.services.myLocker.MyLockerService
+import java.util.concurrent.atomic.AtomicBoolean
 
 class CBLockerService {
     fun scan(context: Context, token: String, callback: IResultCallback<List<SPRLockerModel>>) {
-        CBLockerScanListService().scan(context, token, callback)
+        if (isProcessing.compareAndSet(false, true)) {
+            CBLockerScanListService().scan(context, token, createCallback(callback))
+        }
     }
 
     fun put(context: Context, token: String, spacerId: String, callback: ICallback) {
-        CBLockerScanConnectService().put(context, token, spacerId, callback)
+        if (isProcessing.compareAndSet(false, true)) {
+            CBLockerScanConnectService().put(context, token, spacerId, createCallback(callback))
+        }
     }
 
     fun take(context: Context, token: String, spacerId: String, callback: ICallback) {
-        CBLockerScanConnectService().take(context, token, spacerId, callback)
+        if (isProcessing.compareAndSet(false, true)) {
+            CBLockerScanConnectService().take(context, token, spacerId, createCallback(callback))
+        }
     }
 
     fun openForMaintenance(context: Context, token: String, spacerId: String, callback: ICallback) {
-        CBLockerScanConnectService().openForMaintenance(context, token, spacerId, callback)
+        if (isProcessing.compareAndSet(false, true)) {
+            CBLockerScanConnectService().openForMaintenance(
+                context,
+                token,
+                spacerId,
+                createCallback(callback)
+            )
+        }
     }
 
     fun takeWithUrlKey(context: Context, token: String, urlKey: String, callback: ICallback) {
-        MyLockerService().shareUrlKey(
-            token,
-            urlKey,
-            object : IResultCallback<MyLockerModel> {
-                override fun onSuccess(result: MyLockerModel) = take(context, token, result.id, callback)
-                override fun onFailure(error: SPRError) = callback.onFailure(error)
-            })
+        if (isProcessing.compareAndSet(false, true)) {
+            MyLockerService().shareUrlKey(
+                token,
+                urlKey,
+                object : IResultCallback<MyLockerModel> {
+                    override fun onSuccess(result: MyLockerModel) {
+                        isProcessing.set(false)
+                        take(context, token, result.id, callback)
+                    }
 
+                    override fun onFailure(error: SPRError) {
+                        isProcessing.set(false)
+                        callback.onFailure(error)
+                    }
+                }
+            )
+        }
+    }
+
+    private fun <T> createCallback(callback: IResultCallback<T>): IResultCallback<T> {
+        return object : IResultCallback<T> {
+            override fun onSuccess(result: T) {
+                isProcessing.set(false)
+                callback.onSuccess(result)
+            }
+
+            override fun onFailure(error: SPRError) {
+                isProcessing.set(false)
+                callback.onFailure(error)
+            }
+        }
+    }
+
+    private fun createCallback(callback: ICallback): ICallback {
+        return object : ICallback {
+            override fun onSuccess() {
+                isProcessing.set(false)
+                callback.onSuccess()
+            }
+
+            override fun onFailure(error: SPRError) {
+                isProcessing.set(false)
+                callback.onFailure(error)
+            }
+        }
+    }
+
+    companion object {
+        private val isProcessing = AtomicBoolean(false)
     }
 }

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattMaintenanceService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattMaintenanceService.kt
@@ -19,12 +19,12 @@ class CBLockerGattMaintenanceService : CBLockerGattService() {
     private lateinit var token: String
     private lateinit var callback: ICallback
 
-    fun connect(context: Context, token: String, cbLocker: CBLockerModel, callback: ICallback) {
+    fun connect(context: Context, token: String, cbLocker: CBLockerModel, callback: ICallback, isRetry: Boolean) {
         this.token = token
         this.callback = callback
 
         val gattCallback = CBLockerGattMaintenanceCallback()
-        super.connect(context, cbLocker, gattCallback, CBLockerGattActionType.OpenForMaintenance)
+        super.connect(context, cbLocker, gattCallback, CBLockerGattActionType.OpenForMaintenance, isRetry)
     }
 
     private open inner class CBLockerGattMaintenanceCallback : CBLockerGattCallback() {

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattPutService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattPutService.kt
@@ -20,12 +20,12 @@ class CBLockerGattPutService : CBLockerGattService() {
     private lateinit var token: String
     private lateinit var callback: ICallback
 
-    fun connect(context: Context, token: String, cbLocker: CBLockerModel, callback: ICallback) {
+    fun connect(context: Context, token: String, cbLocker: CBLockerModel, callback: ICallback, isRetry: Boolean) {
         this.token = token
         this.callback = callback
 
         val gattCallback = CBLockerGattPutCallback()
-        super.connect(context, cbLocker, gattCallback, CBLockerGattActionType.Put)
+        super.connect(context, cbLocker, gattCallback, CBLockerGattActionType.Put, isRetry)
     }
 
     private open inner class CBLockerGattPutCallback : CBLockerGattCallback() {

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattService.kt
@@ -45,25 +45,17 @@ open class CBLockerGattService {
 
     @Synchronized
     private fun connectRemoteDevice() {
-        synchronized(lock) {
-            if (canConnecting()) {
-                logd("ーーーーーーーーーーーーーーーーーーーー")
-                logd("コネクトの処理開始")
-                logd("ーーーーーーーーーーーーーーーーーーーー")
-                val remoteDevice = bluetoothAdapter.getRemoteDevice(cbLocker.address)
-                bluetoothGatt = remoteDevice.connectGatt(
-                    context, false, gattCallback, BluetoothDevice.TRANSPORT_LE
-                )
-                timeout.during.set()
-                timeout.start.set()
-            }
-        }
+        val remoteDevice = bluetoothAdapter.getRemoteDevice(cbLocker.address)
+        bluetoothGatt = remoteDevice.connectGatt(
+            context, false, gattCallback, BluetoothDevice.TRANSPORT_LE
+        )
+        timeout.during.set()
+        timeout.start.set()
     }
 
     private fun reset() {
         timeout.clearAll()
         bluetoothGatt?.disconnect()
-        finishConnecting()
     }
 
     @Synchronized
@@ -217,24 +209,5 @@ open class CBLockerGattService {
 
     companion object {
         const val GATT_ERROR_STATE = 133
-        private val lock = Object()
-        private var connecting = false
-
-        fun canConnecting(): Boolean {
-            synchronized(lock) {
-                while (connecting) {
-                    lock.wait()
-                }
-                connecting = true
-                return true
-            }
-        }
-
-        fun finishConnecting() {
-            synchronized(lock) {
-                connecting = false
-                lock.notify()
-            }
-        }
     }
 }

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattService.kt
@@ -2,8 +2,6 @@ package com.spacer.sdk.services.cbLocker.gatt
 
 import android.bluetooth.*
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import com.spacer.sdk.data.ICallback
 import com.spacer.sdk.data.IResultCallback
 import com.spacer.sdk.data.SPRError
@@ -14,73 +12,98 @@ import com.spacer.sdk.values.cbLocker.*
 open class CBLockerGattService {
     private lateinit var context: Context
     protected lateinit var cbLocker: CBLockerModel
-    private lateinit var connectHandler: Handler
     private lateinit var gattCallback: CBLockerGattCallback
     private lateinit var actionType: CBLockerGattActionType
-    private lateinit var gatt: BluetoothGatt
+    private var bluetoothGatt: BluetoothGatt? = null
+    private var isRetry: Boolean = false
+    private var isCanceled = false
 
     protected val spacerId get() = cbLocker.spacerId
     private val bluetoothAdapter get() = (context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager).adapter
-    private var connectRetryCnt = 0
-    private var isRetry = false
     private var timeout = CBLockerConnectTimeouts { error ->
-        gatt.disconnect()
-        gatt.close()
-        timeoutClearAll()
-
-        connectRetryCnt++
-        if (connectRetryCnt > CBLockerConst.MaxRetryNum) {
-            cbLocker.reset()
-            gattCallback.onFailure(error)
-        } else {
-            isRetry = true
-            connectRemoteDevice()
-        }
+        failureIfNotCanceled(error)
     }
 
 
-    open fun connect(context: Context, cbLocker: CBLockerModel, gattCallback: CBLockerGattCallback, actionType: CBLockerGattActionType) {
+    open fun connect(
+        context: Context,
+        cbLocker: CBLockerModel,
+        gattCallback: CBLockerGattCallback,
+        actionType: CBLockerGattActionType,
+        isRetry: Boolean
+    ) {
         logd("connect: ${cbLocker.spacerId} ")
 
         this.context = context
         this.cbLocker = cbLocker
         this.gattCallback = gattCallback
-        this.connectHandler = Handler(Looper.getMainLooper())
         this.actionType = actionType
+        this.isRetry = isRetry
 
         connectRemoteDevice()
     }
 
+    @Synchronized
     private fun connectRemoteDevice() {
-        timeout.clearAll()
-        val remoteDevice = bluetoothAdapter.getRemoteDevice(cbLocker.address)
-        gatt = remoteDevice.connectGatt(
-            context, false, gattCallback, BluetoothDevice.TRANSPORT_LE
-        )
-        timeout.during.set()
-        timeout.start.set()
+        synchronized(lock) {
+            if (canConnecting()) {
+                logd("ーーーーーーーーーーーーーーーーーーーー")
+                logd("コネクトの処理開始")
+                logd("ーーーーーーーーーーーーーーーーーーーー")
+                val remoteDevice = bluetoothAdapter.getRemoteDevice(cbLocker.address)
+                bluetoothGatt = remoteDevice.connectGatt(
+                    context, false, gattCallback, BluetoothDevice.TRANSPORT_LE
+                )
+                timeout.during.set()
+                timeout.start.set()
+            }
+        }
     }
 
-    private fun timeoutClearAll(){
+    private fun reset() {
         timeout.clearAll()
+        bluetoothGatt?.disconnect()
+        finishConnecting()
+    }
+
+    @Synchronized
+    private fun successIfNotCanceled() {
+        cbLocker.reset()
+        reset()
+        if (!isCanceled) {
+            isCanceled = true
+            gattCallback.onSuccess()
+        }
+    }
+
+    @Synchronized
+    private fun failureIfNotCanceled(error: SPRError) {
+        reset()
+        if (!isCanceled) {
+            isCanceled = true
+            gattCallback.onFailure(error)
+        }
     }
 
     open inner class CBLockerGattCallback : BluetoothGattCallback(), ICallback {
 
         override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
-            timeout.start.clear()
             logd("onConnectionStateChange: $status, $newState")
 
             when {
                 newState == BluetoothGatt.STATE_CONNECTED -> {
+                    timeout.start.clear()
                     gatt.discoverServices()
                     timeout.discover.set()
                 }
                 status == GATT_ERROR_STATE -> {
-                    connectRemoteDevice()
+                    failureIfNotCanceled(SPRError.CBServiceNotFound)
+
                 }
                 newState == BluetoothGatt.STATE_DISCONNECTED -> {
-                    gatt.close()
+                    bluetoothGatt?.close()
+                    bluetoothGatt = null
+
                 }
             }
         }
@@ -88,14 +111,16 @@ open class CBLockerGattService {
         override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
             timeout.discover.clear()
             if (status != BluetoothGatt.GATT_SUCCESS) {
-                return gatt.fail(SPRError.CBServiceNotFound)
+                return failureIfNotCanceled(SPRError.CBServiceNotFound)
             }
 
-            val service = gatt.services.firstOrNull { it.uuid == CBLockerConst.DeviceServiceUUID } ?: return gatt.fail(SPRError.CBServiceNotFound)
+            val service =
+                gatt.services.firstOrNull { it.uuid == CBLockerConst.DeviceServiceUUID } ?: return failureIfNotCanceled(SPRError.CBServiceNotFound)
 
-            val characteristic = service.characteristics.firstOrNull { it.uuid == CBLockerConst.DeviceCharacteristicUUID } ?: return gatt.fail(
-                SPRError.CBCharacteristicNotFound
-            )
+            val characteristic =
+                service.characteristics.firstOrNull { it.uuid == CBLockerConst.DeviceCharacteristicUUID } ?: return failureIfNotCanceled(
+                    SPRError.CBCharacteristicNotFound
+                )
 
             gatt.readCharacteristic(characteristic)
             if (cbLocker.status == CBLockerGattStatus.None) {
@@ -118,16 +143,16 @@ open class CBLockerGattService {
             }
 
             if (BluetoothGatt.GATT_SUCCESS != status) {
-                return gatt.fail(SPRError.CBReadingCharacteristicFailed)
+                return failureIfNotCanceled(SPRError.CBReadingCharacteristicFailed)
             }
 
             if (isRetry && alreadyWrittenToCharacteristic(characteristic.readData())) {
-                gatt.finish(characteristic, cbLocker)
+                finish(characteristic, cbLocker)
             } else {
                 if (cbLocker.status == CBLockerGattStatus.None) {
                     gatt.getKeyAndWriteCharacteristic(characteristic, cbLocker)
                 } else {
-                    gatt.finish(characteristic, cbLocker)
+                    finish(characteristic, cbLocker)
                 }
             }
         }
@@ -137,7 +162,7 @@ open class CBLockerGattService {
             timeout.write.clear()
 
             if (BluetoothGatt.GATT_SUCCESS != status) {
-                return gatt.fail(SPRError.CBWritingCharacteristicFailed)
+                return failureIfNotCanceled(SPRError.CBWritingCharacteristicFailed)
             }
             cbLocker.update(CBLockerGattStatus.Write)
             gatt.readCharacteristic(characteristic)
@@ -164,43 +189,19 @@ open class CBLockerGattService {
                     timeout.write.set()
                 }
 
-                override fun onFailure(error: SPRError) = fail(error)
+                override fun onFailure(error: SPRError) = failureIfNotCanceled(error)
             }
 
             onKeyGet(characteristic, cbLocker, callback)
         }
 
-        private fun BluetoothGatt.finish(characteristic: BluetoothGattCharacteristic, cbLocker: CBLockerModel) {
+        private fun finish(characteristic: BluetoothGattCharacteristic, cbLocker: CBLockerModel) {
             val callback = object : ICallback {
-                override fun onSuccess() = success()
-                override fun onFailure(error: SPRError) = fail(error)
+                override fun onSuccess() = successIfNotCanceled()
+                override fun onFailure(error: SPRError) = failureIfNotCanceled(error)
             }
 
             onFinished(characteristic, cbLocker, callback)
-        }
-
-        private fun BluetoothGatt.reset() {
-            cbLocker.reset()
-            disconnect()
-            timeout.clearAll()
-        }
-
-        private fun BluetoothGatt.success() {
-            onSuccess()
-            reset()
-        }
-
-        private fun BluetoothGatt.fail(error: SPRError) {
-            connectRetryCnt++
-            if (connectRetryCnt > CBLockerConst.MaxRetryNum) {
-                onFailure(error)
-                reset()
-            } else {
-                isRetry = true
-                disconnect()
-                close()
-                connectRemoteDevice()
-            }
         }
 
         protected fun BluetoothGattCharacteristic.readData() = this.value.toString(Charsets.UTF_8)
@@ -216,5 +217,24 @@ open class CBLockerGattService {
 
     companion object {
         const val GATT_ERROR_STATE = 133
+        private val lock = Object()
+        private var connecting = false
+
+        fun canConnecting(): Boolean {
+            synchronized(lock) {
+                while (connecting) {
+                    lock.wait()
+                }
+                connecting = true
+                return true
+            }
+        }
+
+        fun finishConnecting() {
+            synchronized(lock) {
+                connecting = false
+                lock.notify()
+            }
+        }
     }
 }

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattTakeService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattTakeService.kt
@@ -20,12 +20,12 @@ class CBLockerGattTakeService : CBLockerGattService() {
     private lateinit var token: String
     private lateinit var callback: ICallback
 
-    fun connect(context: Context, token: String, cbLocker: CBLockerModel, callback: ICallback) {
+    fun connect(context: Context, token: String, cbLocker: CBLockerModel, callback: ICallback, isRetry: Boolean) {
         this.token = token
         this.callback = callback
 
         val gattCallback = CBLockerGattTakeCallback()
-        super.connect(context, cbLocker, gattCallback, CBLockerGattActionType.Take)
+        super.connect(context, cbLocker, gattCallback, CBLockerGattActionType.Take, isRetry)
     }
 
     private open inner class CBLockerGattTakeCallback : CBLockerGattCallback() {

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
@@ -89,7 +89,6 @@ class CBLockerScanConnectService : CBLockerScanService() {
 
     fun retryOrFailure(error: SPRError, executable: () -> Unit, retryNum: Int, cbLocker: CBLockerModel, callback: ICallback) {
         if (retryNum <= CBLockerConst.MaxRetryNum) {
-            logd("リトライカウント = $retryNum")
             executable.invoke()
         } else {
             cbLocker.reset()

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
@@ -84,11 +84,7 @@ class CBLockerScanConnectService : CBLockerScanService() {
                 )
         }
 
-        when (type) {
-            CBLockerGattActionType.Put -> CBLockerGattPutService().connect(context, token, cbLocker, retryCallback, isRetry)
-            CBLockerGattActionType.Take -> CBLockerGattTakeService().connect(context, token, cbLocker, retryCallback, isRetry)
-            CBLockerGattActionType.OpenForMaintenance -> CBLockerGattMaintenanceService().connect(context, token, cbLocker, retryCallback, isRetry)
-        }
+        createCBLockerGattServiceWithConnect(type, context, token, cbLocker, retryCallback, isRetry)
     }
 
     fun retryOrFailure(error: SPRError, executable: () -> Unit, retryNum: Int, cbLocker: CBLockerModel, callback: ICallback) {
@@ -98,6 +94,14 @@ class CBLockerScanConnectService : CBLockerScanService() {
         } else {
             cbLocker.reset()
             callback.onFailure(error)
+        }
+    }
+
+    private fun createCBLockerGattServiceWithConnect(type: CBLockerGattActionType, context: Context, token: String, cbLocker: CBLockerModel, retryCallback: ICallback, isRetry: Boolean) {
+        return when (type) {
+            CBLockerGattActionType.Put -> CBLockerGattPutService().connect(context, token, cbLocker, retryCallback, isRetry)
+            CBLockerGattActionType.Take -> CBLockerGattTakeService().connect(context, token, cbLocker, retryCallback, isRetry)
+            CBLockerGattActionType.OpenForMaintenance -> CBLockerGattMaintenanceService().connect(context, token, cbLocker, retryCallback, isRetry)
         }
     }
 

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
@@ -4,10 +4,13 @@ import android.content.Context
 import com.spacer.sdk.data.ICallback
 import com.spacer.sdk.data.IResultCallback
 import com.spacer.sdk.data.SPRError
+import com.spacer.sdk.data.extensions.LoggerExtensions.logd
 import com.spacer.sdk.models.cbLocker.CBLockerModel
 import com.spacer.sdk.services.cbLocker.gatt.CBLockerGattPutService
 import com.spacer.sdk.services.cbLocker.gatt.CBLockerGattTakeService
 import com.spacer.sdk.services.cbLocker.gatt.CBLockerGattMaintenanceService
+import com.spacer.sdk.values.cbLocker.CBLockerConst
+import com.spacer.sdk.values.cbLocker.CBLockerGattActionType
 
 class CBLockerScanConnectService : CBLockerScanService() {
     private lateinit var spacerId: String
@@ -26,7 +29,9 @@ class CBLockerScanConnectService : CBLockerScanService() {
             context,
             spacerId,
             object : IResultCallback<CBLockerModel> {
-                override fun onSuccess(result: CBLockerModel) = CBLockerGattPutService().connect(context, token, result, callback)
+                override fun onSuccess(result: CBLockerModel) =
+                    connectWithRetry(CBLockerGattActionType.Put, context, token, result, callback, 0, false)
+                
                 override fun onFailure(error: SPRError) = callback.onFailure(error)
             }
         )
@@ -37,7 +42,9 @@ class CBLockerScanConnectService : CBLockerScanService() {
             context,
             spacerId,
             object : IResultCallback<CBLockerModel> {
-                override fun onSuccess(result: CBLockerModel) = CBLockerGattTakeService().connect(context, token, result, callback)
+                override fun onSuccess(result: CBLockerModel) =
+                    connectWithRetry(CBLockerGattActionType.Take, context, token, result, callback, 0, false)
+
                 override fun onFailure(error: SPRError) = callback.onFailure(error)
             }
         )
@@ -48,10 +55,50 @@ class CBLockerScanConnectService : CBLockerScanService() {
             context,
             spacerId,
             object : IResultCallback<CBLockerModel> {
-                override fun onSuccess(result: CBLockerModel) = CBLockerGattMaintenanceService().connect(context, token, result, callback)
+                override fun onSuccess(result: CBLockerModel) =
+                    connectWithRetry(CBLockerGattActionType.OpenForMaintenance, context, token, result, callback, 0, false)
+
                 override fun onFailure(error: SPRError) = callback.onFailure(error)
             }
         )
+    }
+
+    fun connectWithRetry(
+        type: CBLockerGattActionType,
+        context: Context,
+        token: String,
+        cbLocker: CBLockerModel,
+        callback: ICallback,
+        retryNum: Int,
+        isRetry: Boolean
+    ) {
+        val retryCallback = object : ICallback {
+            override fun onSuccess() = callback.onSuccess()
+            override fun onFailure(error: SPRError) =
+                retryOrFailure(
+                    error,
+                    { connectWithRetry(type, context, token, cbLocker, callback, retryNum + 1, true) },
+                    retryNum + 1,
+                    cbLocker,
+                    callback
+                )
+        }
+
+        when (type) {
+            CBLockerGattActionType.Put -> CBLockerGattPutService().connect(context, token, cbLocker, retryCallback, isRetry)
+            CBLockerGattActionType.Take -> CBLockerGattTakeService().connect(context, token, cbLocker, retryCallback, isRetry)
+            CBLockerGattActionType.OpenForMaintenance -> CBLockerGattMaintenanceService().connect(context, token, cbLocker, retryCallback, isRetry)
+        }
+    }
+
+    fun retryOrFailure(error: SPRError, executable: () -> Unit, retryNum: Int, cbLocker: CBLockerModel, callback: ICallback) {
+        if (retryNum <= CBLockerConst.MaxRetryNum) {
+            logd("リトライカウント = $retryNum")
+            executable.invoke()
+        } else {
+            cbLocker.reset()
+            callback.onFailure(error)
+        }
     }
 
     private inner class CBLockerScanConnectCallback : CBLockerScanCallback() {

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
@@ -30,8 +30,16 @@ class CBLockerScanConnectService : CBLockerScanService() {
             spacerId,
             object : IResultCallback<CBLockerModel> {
                 override fun onSuccess(result: CBLockerModel) =
-                    connectWithRetry(CBLockerGattActionType.Put, context, token, result, callback, 0, false)
-                
+                    connectWithRetry(
+                        CBLockerGattActionType.Put,
+                        context,
+                        token,
+                        result,
+                        callback,
+                        0,
+                        false
+                    )
+
                 override fun onFailure(error: SPRError) = callback.onFailure(error)
             }
         )
@@ -43,7 +51,15 @@ class CBLockerScanConnectService : CBLockerScanService() {
             spacerId,
             object : IResultCallback<CBLockerModel> {
                 override fun onSuccess(result: CBLockerModel) =
-                    connectWithRetry(CBLockerGattActionType.Take, context, token, result, callback, 0, false)
+                    connectWithRetry(
+                        CBLockerGattActionType.Take,
+                        context,
+                        token,
+                        result,
+                        callback,
+                        0,
+                        false
+                    )
 
                 override fun onFailure(error: SPRError) = callback.onFailure(error)
             }
@@ -56,7 +72,15 @@ class CBLockerScanConnectService : CBLockerScanService() {
             spacerId,
             object : IResultCallback<CBLockerModel> {
                 override fun onSuccess(result: CBLockerModel) =
-                    connectWithRetry(CBLockerGattActionType.OpenForMaintenance, context, token, result, callback, 0, false)
+                    connectWithRetry(
+                        CBLockerGattActionType.OpenForMaintenance,
+                        context,
+                        token,
+                        result,
+                        callback,
+                        0,
+                        false
+                    )
 
                 override fun onFailure(error: SPRError) = callback.onFailure(error)
             }
@@ -77,17 +101,32 @@ class CBLockerScanConnectService : CBLockerScanService() {
             override fun onFailure(error: SPRError) =
                 retryOrFailure(
                     error,
-                    { connectWithRetry(type, context, token, cbLocker, callback, retryNum + 1, true) },
+                    {
+                        connectWithRetry(
+                            type,
+                            context,
+                            token,
+                            cbLocker,
+                            callback,
+                            retryNum + 1,
+                            true
+                        )
+                    },
                     retryNum + 1,
                     cbLocker,
                     callback
                 )
         }
-
         createCBLockerGattServiceWithConnect(type, context, token, cbLocker, retryCallback, isRetry)
     }
 
-    fun retryOrFailure(error: SPRError, executable: () -> Unit, retryNum: Int, cbLocker: CBLockerModel, callback: ICallback) {
+    fun retryOrFailure(
+        error: SPRError,
+        executable: () -> Unit,
+        retryNum: Int,
+        cbLocker: CBLockerModel,
+        callback: ICallback
+    ) {
         if (retryNum <= CBLockerConst.MaxRetryNum) {
             executable.invoke()
         } else {
@@ -96,11 +135,36 @@ class CBLockerScanConnectService : CBLockerScanService() {
         }
     }
 
-    private fun createCBLockerGattServiceWithConnect(type: CBLockerGattActionType, context: Context, token: String, cbLocker: CBLockerModel, retryCallback: ICallback, isRetry: Boolean) {
+    private fun createCBLockerGattServiceWithConnect(
+        type: CBLockerGattActionType,
+        context: Context,
+        token: String,
+        cbLocker: CBLockerModel,
+        retryCallback: ICallback,
+        isRetry: Boolean
+    ) {
         return when (type) {
-            CBLockerGattActionType.Put -> CBLockerGattPutService().connect(context, token, cbLocker, retryCallback, isRetry)
-            CBLockerGattActionType.Take -> CBLockerGattTakeService().connect(context, token, cbLocker, retryCallback, isRetry)
-            CBLockerGattActionType.OpenForMaintenance -> CBLockerGattMaintenanceService().connect(context, token, cbLocker, retryCallback, isRetry)
+            CBLockerGattActionType.Put -> CBLockerGattPutService().connect(
+                context,
+                token,
+                cbLocker,
+                retryCallback,
+                isRetry
+            )
+            CBLockerGattActionType.Take -> CBLockerGattTakeService().connect(
+                context,
+                token,
+                cbLocker,
+                retryCallback,
+                isRetry
+            )
+            CBLockerGattActionType.OpenForMaintenance -> CBLockerGattMaintenanceService().connect(
+                context,
+                token,
+                cbLocker,
+                retryCallback,
+                isRetry
+            )
         }
     }
 

--- a/sdk/src/main/java/com/spacer/sdk/values/cbLocker/CBLockerTimeout.kt
+++ b/sdk/src/main/java/com/spacer/sdk/values/cbLocker/CBLockerTimeout.kt
@@ -21,7 +21,7 @@ class CBLockerTimeout(private val seconds: Long, private val timeoutAction: () -
     }
 }
 
-class CBLockerConnectTimeouts(retryOrFailure: (SPRError) -> Unit) : ICallback {
+class CBLockerConnectTimeouts(retryOrFailure: (SPRError) -> Unit) {
     var start = CBLockerTimeout(CBLockerConst.StartTimeoutSeconds) { retryOrFailure(SPRError.CBConnectStartTimeout) }
     var discover = CBLockerTimeout(CBLockerConst.DiscoverTimeoutSeconds) { retryOrFailure(SPRError.CBConnectDiscoverTimeout) }
     var readBeforeWrite = CBLockerTimeout(CBLockerConst.ReadTimeoutSeconds) { retryOrFailure(SPRError.CBConnectReadTimeoutBeforeWrite) }


### PR DESCRIPTION
APL-839 【kotlin｜バグ】ロッカーを検出後、開錠しようとすると複数エラーが出てアプリが落ちる（西部新宿　SPACER55281）
https://spacer-inc.backlog.com/view/APL-839

### 修正内容
・リトライする場所を変更
・CBLockerServiceの各メソッドが同時に実行できないように制御

### テスト
・put,take,openForMaintenance各メソッド内でエラーが起きた時にリトライし、処理が成功すること。
・scan,put,take,openForMaintenance,takeWithUrlKey各メソッドが同時に複数実行できないこと。