### PR TITLE
APL-868 scanWithSpacerId、putWithDeviceAddress、takeWithDeviceAddressを追加

### DIFF
--- a/app/src/main/java/com/spacer/example/presentation/cbLocker/CBLockerListener.kt
+++ b/app/src/main/java/com/spacer/example/presentation/cbLocker/CBLockerListener.kt
@@ -17,8 +17,18 @@ class CBLockerListener(private val fragment: Fragment) {
         override fun onClicked() {
             val context = fragment.context ?: return
 
-            requester.runList<SPRLockerModel>(DialogMessage.CbLockerScanSuccess) {
+            requester.runList<SPRLockerModel>(DialogMessage.CbLockerScanLockersSuccess) {
                 service.scan(context, SdkToken, it)
+            }
+        }
+    }
+
+    val scanWithSpacerId = object : ICardInputViewListener {
+        override fun onClicked(text: String) {
+            val context = fragment.context ?: return
+
+            requester.runGet<SPRLockerModel>(DialogMessage.CbLockerScanLockerSuccess) {
+                service.scanWithSpacerId(context, SdkToken, text, it)
             }
         }
     }

--- a/app/src/main/java/com/spacer/example/presentation/cbLocker/CBLockerViewModel.kt
+++ b/app/src/main/java/com/spacer/example/presentation/cbLocker/CBLockerViewModel.kt
@@ -7,7 +7,8 @@ import com.spacer.example.presentation.common.header.HeaderViewModel
 
 class CBLockerViewModel : ViewModel() {
     val header = HeaderViewModel().apply { init(R.string.cb_title) }
-    val scan = CardViewModel().apply { init(R.string.cb_scan_title, R.string.cb_scan_desc) }
+    val scan = CardViewModel().apply { init(R.string.cb_scan_lockers_title, R.string.cb_scan_lockers_desc) }
+    val scanWithSpacerId = CardViewModel().apply { init(R.string.cb_scan_locker_title, R.string.cb_scan_locker_desc, R.string.cb_scan_locker_hint) }
     val put = CardViewModel().apply { init(R.string.cb_put_title, R.string.cb_put_desc, R.string.cb_put_hint) }
     val take = CardViewModel().apply { init(R.string.cb_take_title, R.string.cb_take_desc, R.string.cb_take_hint) }
     val openForMaintenance = CardViewModel().apply { init(R.string.cb_open_for_maintenance_title, R.string.cb_open_for_maintenance_desc, R.string.cb_open_for_maintenance_hint) }

--- a/app/src/main/java/com/spacer/example/presentation/common/dialog/DialogMessage.kt
+++ b/app/src/main/java/com/spacer/example/presentation/common/dialog/DialogMessage.kt
@@ -25,7 +25,8 @@ class DialogMessage {
     override fun toString() = "${title},${body}"
 
     companion object {
-        val CbLockerScanSuccess = DialogMessage(R.string.success_title, R.string.cb_scan_success_message)
+        val CbLockerScanLockersSuccess = DialogMessage(R.string.success_title, R.string.cb_scan_lockers_success_message)
+        val CbLockerScanLockerSuccess = DialogMessage(R.string.success_title, R.string.cb_scan_locker_success_message)
         val CbLockerPutSuccess = DialogMessage(R.string.success_title, R.string.cb_put_success_message)
         val CbLockerTakeSuccess = DialogMessage(R.string.success_title, R.string.cb_take_success_message)
         val CbLockerOpenForMaintenanceSuccess = DialogMessage(R.string.success_title, R.string.cb_open_for_maintenance_success_message)

--- a/app/src/main/res/layout/fragment_cb_locker.xml
+++ b/app/src/main/res/layout/fragment_cb_locker.xml
@@ -53,6 +53,14 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
+                    app:listener="@{listener.scanWithSpacerId}"
+                    app:viewModel="@{viewModel.scanWithSpacerId}" />
+
+                <include
+                    layout="@layout/view_card_input"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
                     app:listener="@{listener.put}"
                     app:viewModel="@{viewModel.put}" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,9 +14,15 @@
     <string name="my_title">My Locker Service</string>
     <string name="spr_title">SPR Locker Service</string>
 
-    <string name="cb_scan_title">scan lockers</string>
-    <string name="cb_scan_desc">use bluetooth to detect locker in front of you.</string>
-    <string name="cb_scan_success_message">succeeded in scanning</string>
+    <string name="cb_scan_lockers_title">scan lockers</string>
+    <string name="cb_scan_lockers_desc">use bluetooth to detect locker in front of you.</string>
+    <string name="cb_scan_lockers_success_message">succeeded in scanning</string>
+
+    <string name="cb_scan_locker_title">scan locker</string>
+    <string name="cb_scan_locker_desc">use bluetooth to detect specific locker.</string>
+    <string name="cb_scan_locker_hint">spacer id</string>
+    <string name="cb_scan_locker_success_message">succeeded in scanning</string>
+
 
     <string name="cb_put_title">put in locker</string>
     <string name="cb_put_desc">connect to locker with bluetooth and put your luggage in locker.</string>

--- a/sdk/src/main/java/com/spacer/sdk/models/sprLocker/SPRLockerModel.kt
+++ b/sdk/src/main/java/com/spacer/sdk/models/sprLocker/SPRLockerModel.kt
@@ -6,13 +6,25 @@ import com.spacer.sdk.data.api.resData.sprLocker.SPRLockerResData
 import com.spacer.sdk.data.extensions.EnumExtensions.safeValueOf
 import com.spacer.sdk.values.sprLocker.SPRLockerStatus
 
-class SPRLockerModel(val id: String, val status: SPRLockerStatus, val size: String?, val closedWait: String, val version: String,  val doorStatus: String, val doorStatusExpiredAt: String?) {
-    override fun toString() = "id:${id},status:${status.text},size:${size},closedWait:${closedWait},version:${version},doorStatus:${doorStatus},doorStatusExpiredAt:${doorStatusExpiredAt}"
+class SPRLockerModel(
+    val id: String,
+    var address: String,
+    val status: SPRLockerStatus,
+    val size: String?,
+    val closedWait: String,
+    val version: String,
+    val doorStatus: String,
+    val doorStatusExpiredAt: String?
+) {
+    override fun toString() =
+        "id:${id},address:${address},status:${status.text},size:${size},closedWait:${closedWait},version:${version},doorStatus:${doorStatus},doorStatusExpiredAt:${doorStatusExpiredAt}"
 }
 
 fun SPRLockerResData.toModel(): SPRLockerModel {
     val status = safeValueOf(status, SPRLockerStatus.Unknown)
-    return SPRLockerModel(id, status, size, closedWait, version, doorStatus, doorStatusExpiredAt)
+    return SPRLockerModel(
+        id, "", status, size, closedWait, version, doorStatus, doorStatusExpiredAt
+    )
 }
 
 class SPRLockerListMapper : IMapper<SPRLockerGetResData, List<SPRLockerModel>> {

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanListService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanListService.kt
@@ -5,7 +5,6 @@ import com.spacer.sdk.data.IResultCallback
 import com.spacer.sdk.data.SPRError
 import com.spacer.sdk.models.cbLocker.CBLockerModel
 import com.spacer.sdk.models.sprLocker.SPRLockerModel
-import com.spacer.sdk.services.sprLocker.SPRLockerService
 
 class CBLockerScanListService : CBLockerScanService() {
     private lateinit var token: String
@@ -30,7 +29,7 @@ class CBLockerScanListService : CBLockerScanService() {
 
         override fun onDelayed(): Boolean {
             return if (scanningList.size > 0) {
-                scanningList.parse(callback)
+                scanningList.parse(token, callback)
                 true
             } else {
                 false
@@ -38,10 +37,5 @@ class CBLockerScanListService : CBLockerScanService() {
         }
 
         override fun onFailure(error: SPRError) = callback.onFailure(error)
-
-        private fun MutableList<CBLockerModel>.parse(callback: IResultCallback<List<SPRLockerModel>>) {
-            val spacerIds = this.map { it.spacerId }
-            SPRLockerService().getLockers(token, spacerIds, callback)
-        }
     }
 }

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanSingleService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanSingleService.kt
@@ -1,0 +1,50 @@
+package com.spacer.sdk.services.cbLocker.scan
+
+import android.content.Context
+import com.spacer.sdk.data.IResultCallback
+import com.spacer.sdk.data.SPRError
+import com.spacer.sdk.models.cbLocker.CBLockerModel
+import com.spacer.sdk.models.sprLocker.SPRLockerModel
+
+open class CBLockerScanSingleService : CBLockerScanService() {
+    private lateinit var spacerId: String
+    private lateinit var callback: IResultCallback<CBLockerModel>
+
+    protected fun scan(context: Context, spacerId: String, callback: IResultCallback<CBLockerModel>) {
+        this.spacerId = spacerId
+        this.callback = callback
+
+        val scanCallback = CBLockerScanSingleCallback()
+        super.startScan(context, scanCallback)
+    }
+
+    fun scanWithSpacerId(
+        context: Context, token: String, spacerId: String, callback: IResultCallback<SPRLockerModel>
+    ) {
+        scan(context, spacerId, object : IResultCallback<CBLockerModel> {
+            override fun onSuccess(result: CBLockerModel) {
+                mutableListOf(result).parse(token, object : IResultCallback<List<SPRLockerModel>> {
+                    override fun onSuccess(result: List<SPRLockerModel>) =
+                        callback.onSuccess(result.first())
+
+                    override fun onFailure(error: SPRError) = callback.onFailure(error)
+                })
+            }
+
+            override fun onFailure(error: SPRError) = callback.onFailure(error)
+        })
+    }
+
+    private inner class CBLockerScanSingleCallback : CBLockerScanCallback() {
+        override fun onDiscovered(cbLocker: CBLockerModel) {
+            if (cbLocker.spacerId == spacerId) {
+                stopScan()
+                callback.onSuccess(cbLocker)
+            }
+        }
+
+        override fun onDelayed() = !isScanning
+
+        override fun onFailure(error: SPRError) = callback.onFailure(error)
+    }
+}


### PR DESCRIPTION
APL-868 [android SDK]施錠、解錠時のスキャンを省略できるように対応
https://spacer-inc.backlog.com/view/APL-868

### 修正内容
・scanWithSpacerId（特定の筐体のみスキャン）を追加
・putWithDeviceAddress（コネクトのみ実行する施錠）を追加
・takeWithDeviceAddress（コネクトのみ実行する解錠）を追加

### テスト
・scanWithSpacerIdで指定したロッカーを検出できること
・putWithDeviceAddressで施錠できること
・takeWithDeviceAddressで施錠できること