### PR TITLE
update: targetSDKを33に変更

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "30.0.0"
     def properties = new Properties()
 
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         applicationId "com.spacer.example"
         minSdkVersion 23
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "30.0.0"
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
APL-892 [Kotlin] Google Playの対象APIレベルを33に変更する
https://spacer-inc.backlog.com/view/APL-892

### 修正内容
・targetSdkVersionを33に変更

### テスト
・scan、put、takeそれぞれ通常利用できること