### PR TITLE
APL-992 [android SDK]アプリから施錠時の2回目のreadリクエストをなくす

### DIFF
--- a/sdk/src/main/java/com/spacer/sdk/data/SPRError.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/SPRError.kt
@@ -34,7 +34,6 @@ data class SPRError(
         val CBConnectStartTimeout = SPRError("E22011201", "timeout occurred while connecting to peripheral")
         val CBConnectDiscoverTimeout = SPRError("E22011202", "timeout occurred while discovering characteristic")
         val CBConnectReadTimeoutBeforeWrite = SPRError("E22011203", "timeout occurred while reading the value of the characteristic before write")
-        val CBConnectReadTimeoutAfterWrite = SPRError("E22011204", "timeout occurred while reading the value of the characteristic after write")
         val CBConnectWriteTimeout = SPRError("E22011205", "timeout occurred while writing value to characteristic")
         val CBConnectDuringTimeout = SPRError("E22011206", "timeout occurred during connection processing")
     }

--- a/sdk/src/main/java/com/spacer/sdk/data/api/reqData/key/KeyGenerateResultReqData.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/reqData/key/KeyGenerateResultReqData.kt
@@ -2,5 +2,4 @@ package com.spacer.sdk.data.api.reqData.key
 
 data class KeyGenerateResultReqData(
     val spacerId: String,
-    val readData: String,
 )

--- a/sdk/src/main/java/com/spacer/sdk/data/api/reqData/key/KeyGetResultReqData.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/reqData/key/KeyGetResultReqData.kt
@@ -2,5 +2,4 @@ package com.spacer.sdk.data.api.reqData.key
 
 data class KeyGetResultReqData(
     val spacerId: String,
-    val readData: String,
 )

--- a/sdk/src/main/java/com/spacer/sdk/data/api/reqData/key/MaintenanceKeyGetResultReqData.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/reqData/key/MaintenanceKeyGetResultReqData.kt
@@ -2,5 +2,4 @@ package com.spacer.sdk.data.api.reqData.key
 
 data class MaintenanceKeyGetResultReqData(
     val spacerId: String,
-    val readData: String,
 )

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattMaintenanceService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattMaintenanceService.kt
@@ -36,8 +36,8 @@ class CBLockerGattMaintenanceService : CBLockerGattService() {
             api.key.getMaintenance(APIHeader.createHeader(token), params).enqueue(callback, mapper)
         }
 
-        override fun onFinished(characteristic: BluetoothGattCharacteristic, cbLocker: CBLockerModel, callback: ICallback) {
-            val params = MaintenanceKeyGetResultReqData(spacerId, characteristic.readData())
+        override fun onFinished(callback: ICallback) {
+            val params = MaintenanceKeyGetResultReqData(spacerId)
             api.key.getMaintenanceResult(APIHeader.createHeader(token), params).enqueue(callback)
         }
 

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattPutService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattPutService.kt
@@ -37,8 +37,8 @@ class CBLockerGattPutService : CBLockerGattService() {
             api.key.generate(APIHeader.createHeader(token), params).enqueue(callback, mapper)
         }
 
-        override fun onFinished(characteristic: BluetoothGattCharacteristic, cbLocker: CBLockerModel, callback: ICallback) {
-            val params = KeyGenerateResultReqData(spacerId, characteristic.readData())
+        override fun onFinished(callback: ICallback) {
+            val params = KeyGenerateResultReqData(spacerId)
             api.key.generateResult(APIHeader.createHeader(token), params).enqueue(callback)
         }
 

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattTakeService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattTakeService.kt
@@ -37,8 +37,8 @@ class CBLockerGattTakeService : CBLockerGattService() {
             api.key.get(APIHeader.createHeader(token), params).enqueue(callback, mapper)
         }
 
-        override fun onFinished(characteristic: BluetoothGattCharacteristic, cbLocker: CBLockerModel, callback: ICallback) {
-            val params = KeyGetResultReqData(spacerId, characteristic.readData())
+        override fun onFinished(callback: ICallback) {
+            val params = KeyGetResultReqData(spacerId)
             api.key.getResult(APIHeader.createHeader(token), params).enqueue(callback)
         }
 

--- a/sdk/src/main/java/com/spacer/sdk/values/cbLocker/CBLockerTimeout.kt
+++ b/sdk/src/main/java/com/spacer/sdk/values/cbLocker/CBLockerTimeout.kt
@@ -25,11 +25,10 @@ class CBLockerConnectTimeouts(retryOrFailure: (SPRError) -> Unit) {
     var start = CBLockerTimeout(CBLockerConst.StartTimeoutSeconds) { retryOrFailure(SPRError.CBConnectStartTimeout) }
     var discover = CBLockerTimeout(CBLockerConst.DiscoverTimeoutSeconds) { retryOrFailure(SPRError.CBConnectDiscoverTimeout) }
     var readBeforeWrite = CBLockerTimeout(CBLockerConst.ReadTimeoutSeconds) { retryOrFailure(SPRError.CBConnectReadTimeoutBeforeWrite) }
-    var readAfterWrite = CBLockerTimeout(CBLockerConst.ReadTimeoutSeconds) { retryOrFailure(SPRError.CBConnectReadTimeoutAfterWrite) }
     var write = CBLockerTimeout(CBLockerConst.WriteTimeoutSeconds) { retryOrFailure(SPRError.CBConnectWriteTimeout) }
     var during = CBLockerTimeout(CBLockerConst.DuringTimeoutSeconds) { retryOrFailure(SPRError.CBConnectDuringTimeout) }
 
     fun clearAll() {
-        arrayOf(start, discover, readBeforeWrite, readAfterWrite, write, during).forEach { timeout -> timeout.clear() }
+        arrayOf(start, discover, readBeforeWrite, write, during).forEach { timeout -> timeout.clear() }
     }
 }


### PR DESCRIPTION
## :ticket: チケット
APL-992 [android SDK]アプリから施錠時の2回目のreadリクエストをなくす
https://spacer-inc.backlog.com/view/APL-992

## :memo: 概要
施錠解錠時の筐体のステータスチェックとして行われていた2度目のreadを削除する

## :+1: 対応内容
2度目のreadを削除し、2度目のread時に行っていた処理をwrite完了時に行うように変更

## :white_check_mark: 動作確認
施錠解錠それぞれで以下を確認
　・通常通り成功すること
　・書き込み前の処理で失敗時に、リトライし成功すること
　・書き込み後の処理で失敗時に、リトライし成功すること