### PR TITLE
APL-1002 [Android SDK] アプリ接続の冗長化対応

### DIFF
--- a/app/src/main/java/com/spacer/example/presentation/cbLocker/CBLockerListener.kt
+++ b/app/src/main/java/com/spacer/example/presentation/cbLocker/CBLockerListener.kt
@@ -63,16 +63,6 @@ class CBLockerListener(private val fragment: Fragment) {
         }
     }
 
-    val read = object : ICardInputViewListener {
-        override fun onClicked(text: String) {
-            val context = fragment.context ?: return
-
-            requester.runGet<String>(DialogMessage.CbLockerReadSuccess) {
-                service.read(context, text, it)
-            }
-        }
-    }
-
     val takeUrlKey = object : ICardInputViewListener {
         override fun onClicked(text: String) {
             val context = fragment.context ?: return

--- a/app/src/main/java/com/spacer/example/presentation/cbLocker/CBLockerViewModel.kt
+++ b/app/src/main/java/com/spacer/example/presentation/cbLocker/CBLockerViewModel.kt
@@ -13,5 +13,4 @@ class CBLockerViewModel : ViewModel() {
     val take = CardViewModel().apply { init(R.string.cb_take_title, R.string.cb_take_desc, R.string.cb_take_hint) }
     val openForMaintenance = CardViewModel().apply { init(R.string.cb_open_for_maintenance_title, R.string.cb_open_for_maintenance_desc, R.string.cb_open_for_maintenance_hint) }
     val takeUrlKey = CardViewModel().apply { init(R.string.cb_take_url_key_title, R.string.cb_take_url_key_desc, R.string.cb_take_url_key_hint) }
-    val read = CardViewModel().apply { init(R.string.cb_read_title, R.string.cb_read_desc, R.string.cb_read_hint) }
 }

--- a/app/src/main/res/layout/fragment_cb_locker.xml
+++ b/app/src/main/res/layout/fragment_cb_locker.xml
@@ -88,14 +88,6 @@
                     app:listener="@{listener.openForMaintenance}"
                     app:viewModel="@{viewModel.openForMaintenance}" />
 
-                <include
-                    layout="@layout/view_card_input"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    app:listener="@{listener.read}"
-                    app:viewModel="@{viewModel.read}" />
-
 
             </LinearLayout>
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation 'com.google.android.gms:play-services-location:18.0.0'
 
     implementation "com.squareup.retrofit2:retrofit:2.6.0"
     implementation 'com.squareup.retrofit2:converter-gson:2.4.0'

--- a/sdk/src/main/java/com/spacer/sdk/data/PermissionChecker.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/PermissionChecker.kt
@@ -1,0 +1,16 @@
+package com.spacer.sdk.data
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+
+class PermissionChecker {
+    companion object {
+        fun isLocationPermitted(context: Context): Boolean {
+            return ContextCompat.checkSelfPermission(
+                context, Manifest.permission.ACCESS_FINE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+}

--- a/sdk/src/main/java/com/spacer/sdk/data/api/APIClient.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/APIClient.kt
@@ -43,6 +43,7 @@ class APIClient {
         .client(httpBuilder.build())
         .build()
 
+    val httpLocker: IHttpLockerAPI by lazy { retrofit.create(IHttpLockerAPI::class.java) }
     val key: IKeyAPI by lazy { retrofit.create(IKeyAPI::class.java) }
     val myLocker: IMyLockerAPI by lazy { retrofit.create(IMyLockerAPI::class.java) }
     val sprLocker: ISPRLockerAPI by lazy { retrofit.create(ISPRLockerAPI::class.java) }

--- a/sdk/src/main/java/com/spacer/sdk/data/api/IHttpLockerAPI.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/IHttpLockerAPI.kt
@@ -1,0 +1,27 @@
+package com.spacer.sdk.data.api
+
+import com.spacer.sdk.data.api.reqData.http.HttpLockerReqData
+import com.spacer.sdk.data.api.reqData.key.*
+import com.spacer.sdk.data.api.resData.http.HttpLockerResData
+import com.spacer.sdk.data.api.resData.key.*
+import retrofit2.Call
+import retrofit2.http.POST
+import retrofit2.http.Body
+import retrofit2.http.HeaderMap
+
+interface IHttpLockerAPI {
+    @POST("locationRPi/box/put")
+    fun put(
+        @HeaderMap headers: Map<String, String>, @Body params: HttpLockerReqData
+    ): Call<HttpLockerResData>
+
+    @POST("locationRPi/box/take")
+    fun take(
+        @HeaderMap headers: Map<String, String>, @Body params: HttpLockerReqData
+    ): Call<HttpLockerResData>
+
+    @POST("locationRPi/box/openForMaintenance")
+    fun openForMaintenance(
+        @HeaderMap headers: Map<String, String>, @Body params: HttpLockerReqData
+    ): Call<HttpLockerResData>
+}

--- a/sdk/src/main/java/com/spacer/sdk/data/api/ISPRLockerAPI.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/ISPRLockerAPI.kt
@@ -1,18 +1,26 @@
 package com.spacer.sdk.data.api
 
-import com.spacer.sdk.data.api.reqData.sprLocker.SPRLockerGetReqData
+import com.spacer.sdk.data.api.reqData.sprLocker.SPRLockerListReqData
 import com.spacer.sdk.data.api.reqData.sprLocker.SPRLockerUnitGetReqData
 import com.spacer.sdk.data.api.resData.sprLocker.SPRLockerGetResData
+import com.spacer.sdk.data.api.resData.sprLocker.SPRLockerListResData
 import com.spacer.sdk.data.api.resData.sprLocker.SPRLockerUnitGetResData
 import retrofit2.Call
-import retrofit2.http.Body
-import retrofit2.http.HeaderMap
-import retrofit2.http.POST
+import retrofit2.http.*
 
 interface ISPRLockerAPI {
-    @POST("locker/spacer/get")
-    fun getLockers(@HeaderMap headers: Map<String, String>, @Body params: SPRLockerGetReqData): Call<SPRLockerGetResData>
+    @POST("locker/spacer/list")
+    fun getLockers(
+        @HeaderMap headers: Map<String, String>, @Body params: SPRLockerListReqData
+    ): Call<SPRLockerListResData>
+
+    @GET("locker/spacer/{spacerId}")
+    fun getLocker(
+        @HeaderMap headers: Map<String, String>, @Path("spacerId") spacerId: String
+    ): Call<SPRLockerGetResData>
 
     @POST("locker/unit/get")
-    fun getUnits(@HeaderMap headers: Map<String, String>, @Body params: SPRLockerUnitGetReqData): Call<SPRLockerUnitGetResData>
+    fun getUnits(
+        @HeaderMap headers: Map<String, String>, @Body params: SPRLockerUnitGetReqData
+    ): Call<SPRLockerUnitGetResData>
 }

--- a/sdk/src/main/java/com/spacer/sdk/data/api/reqData/http/HttpLockerReqData.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/reqData/http/HttpLockerReqData.kt
@@ -1,0 +1,7 @@
+package com.spacer.sdk.data.api.reqData.http
+
+data class HttpLockerReqData(
+    val spacerId: String,
+    val lat: Double,
+    val lng: Double,
+)

--- a/sdk/src/main/java/com/spacer/sdk/data/api/reqData/http/HttpLockerReqData.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/reqData/http/HttpLockerReqData.kt
@@ -2,6 +2,6 @@ package com.spacer.sdk.data.api.reqData.http
 
 data class HttpLockerReqData(
     val spacerId: String,
-    val lat: Double,
-    val lng: Double,
+    val lat: Double?,
+    val lng: Double?,
 )

--- a/sdk/src/main/java/com/spacer/sdk/data/api/reqData/sprLocker/SPRLockerGetReqData.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/reqData/sprLocker/SPRLockerGetReqData.kt
@@ -1,5 +1,0 @@
-package com.spacer.sdk.data.api.reqData.sprLocker
-
-data class SPRLockerGetReqData(
-    val spacerIds: List<String>,
-)

--- a/sdk/src/main/java/com/spacer/sdk/data/api/reqData/sprLocker/SPRLockerListReqData.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/reqData/sprLocker/SPRLockerListReqData.kt
@@ -1,0 +1,5 @@
+package com.spacer.sdk.data.api.reqData.sprLocker
+
+data class SPRLockerListReqData(
+    val spacerIds: List<String>,
+)

--- a/sdk/src/main/java/com/spacer/sdk/data/api/resData/http/HttpLockerResData.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/resData/http/HttpLockerResData.kt
@@ -1,10 +1,9 @@
-package com.spacer.sdk.data.api.resData.sprLocker
+package com.spacer.sdk.data.api.resData.http
 
 import com.spacer.sdk.data.api.resData.ErrorResData
 import com.spacer.sdk.data.api.resData.IResData
 
-data class SPRLockerGetResData(
-    val spacer: SPRLockerResData?,
+data class HttpLockerResData(
     override val result: Boolean,
     override val error: ErrorResData?,
 ) : IResData

--- a/sdk/src/main/java/com/spacer/sdk/data/api/resData/sprLocker/SPRLockerListResData.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/resData/sprLocker/SPRLockerListResData.kt
@@ -3,8 +3,8 @@ package com.spacer.sdk.data.api.resData.sprLocker
 import com.spacer.sdk.data.api.resData.ErrorResData
 import com.spacer.sdk.data.api.resData.IResData
 
-data class SPRLockerGetResData(
-    val spacer: SPRLockerResData?,
+data class SPRLockerListResData(
+    val spacers: List<SPRLockerResData>?,
     override val result: Boolean,
     override val error: ErrorResData?,
 ) : IResData

--- a/sdk/src/main/java/com/spacer/sdk/data/api/resData/sprLocker/SPRLockerResData.kt
+++ b/sdk/src/main/java/com/spacer/sdk/data/api/resData/sprLocker/SPRLockerResData.kt
@@ -9,5 +9,6 @@ data class SPRLockerResData(
     val closedWait: String,
     val version: String,
     val doorStatus: String,
-    val doorStatusExpiredAt: String?
+    val doorStatusExpiredAt: String?,
+    val isHttpSupported: Boolean
 ) : Serializable

--- a/sdk/src/main/java/com/spacer/sdk/models/cbLocker/CBLockerModel.kt
+++ b/sdk/src/main/java/com/spacer/sdk/models/cbLocker/CBLockerModel.kt
@@ -8,10 +8,11 @@ class CBLockerModel(
     var status: CBLockerGattStatus = CBLockerGattStatus.None,
     var doorStatus: String = "",
     var isHttpSupported: Boolean = false,
-    var isScanned: Boolean = false
+    var isScanned: Boolean = false,
+    var hasBLERetried: Boolean = false
 ) {
     override fun toString() =
-        "spacerId:${spacerId},address:${address},status:${status},doorStatus:${doorStatus},isHttpSupported:${isHttpSupported},isScanned:${isScanned}"
+        "spacerId:${spacerId},address:${address},status:${status},doorStatus:${doorStatus},isHttpSupported:${isHttpSupported},isScanned:${isScanned},hasBLERetried:${hasBLERetried}"
 
     fun update(status: CBLockerGattStatus) {
         this.status = status

--- a/sdk/src/main/java/com/spacer/sdk/models/cbLocker/CBLockerModel.kt
+++ b/sdk/src/main/java/com/spacer/sdk/models/cbLocker/CBLockerModel.kt
@@ -6,9 +6,12 @@ class CBLockerModel(
     val spacerId: String,
     val address: String,
     var status: CBLockerGattStatus = CBLockerGattStatus.None,
+    var doorStatus: String = "",
+    var isHttpSupported: Boolean = false,
+    var isScanned: Boolean = false
 ) {
     override fun toString() =
-        "spacerId:${spacerId},address:${address},status:${status}"
+        "spacerId:${spacerId},address:${address},status:${status},doorStatus:${doorStatus},isHttpSupported:${isHttpSupported},isScanned:${isScanned}"
 
     fun update(status: CBLockerGattStatus) {
         this.status = status

--- a/sdk/src/main/java/com/spacer/sdk/models/sprLocker/SPRLockerModel.kt
+++ b/sdk/src/main/java/com/spacer/sdk/models/sprLocker/SPRLockerModel.kt
@@ -1,9 +1,12 @@
 package com.spacer.sdk.models.sprLocker
 
 import com.spacer.sdk.data.IMapper
+import com.spacer.sdk.data.api.resData.location.LocationGetResData
 import com.spacer.sdk.data.api.resData.sprLocker.SPRLockerGetResData
+import com.spacer.sdk.data.api.resData.sprLocker.SPRLockerListResData
 import com.spacer.sdk.data.api.resData.sprLocker.SPRLockerResData
 import com.spacer.sdk.data.extensions.EnumExtensions.safeValueOf
+import com.spacer.sdk.models.location.toModel
 import com.spacer.sdk.values.sprLocker.SPRLockerStatus
 
 class SPRLockerModel(
@@ -14,20 +17,35 @@ class SPRLockerModel(
     val closedWait: String,
     val version: String,
     val doorStatus: String,
-    val doorStatusExpiredAt: String?
+    val doorStatusExpiredAt: String?,
+    val isHttpSupported: Boolean,
+    var isScanned: Boolean
 ) {
     override fun toString() =
-        "id:${id},address:${address},status:${status.text},size:${size},closedWait:${closedWait},version:${version},doorStatus:${doorStatus},doorStatusExpiredAt:${doorStatusExpiredAt}"
+        "id:${id},address:${address},status:${status.text},size:${size},closedWait:${closedWait},version:${version},doorStatus:${doorStatus},doorStatusExpiredAt:${doorStatusExpiredAt},isHttpSupported:${isHttpSupported}"
 }
 
 fun SPRLockerResData.toModel(): SPRLockerModel {
     val status = safeValueOf(status, SPRLockerStatus.Unknown)
     return SPRLockerModel(
-        id, "", status, size, closedWait, version, doorStatus, doorStatusExpiredAt
+        id,
+        "",
+        status,
+        size,
+        closedWait,
+        version,
+        doorStatus,
+        doorStatusExpiredAt,
+        isHttpSupported,
+        isScanned = true
     )
 }
 
-class SPRLockerListMapper : IMapper<SPRLockerGetResData, List<SPRLockerModel>> {
-    override fun map(source: SPRLockerGetResData) = source.spacers?.map { it.toModel() } ?: listOf()
+class SPRLockerListMapper : IMapper<SPRLockerListResData, List<SPRLockerModel>> {
+    override fun map(source: SPRLockerListResData) =
+        source.spacers?.map { it.toModel() } ?: listOf()
 }
 
+class SPRLockerGetMapper : IMapper<SPRLockerGetResData, SPRLockerModel> {
+    override fun map(source: SPRLockerGetResData) = source.spacer!!.toModel()
+}

--- a/sdk/src/main/java/com/spacer/sdk/models/sprLocker/SPRLockerModel.kt
+++ b/sdk/src/main/java/com/spacer/sdk/models/sprLocker/SPRLockerModel.kt
@@ -37,7 +37,7 @@ fun SPRLockerResData.toModel(): SPRLockerModel {
         doorStatus,
         doorStatusExpiredAt,
         isHttpSupported,
-        isScanned = true
+        isScanned = false
     )
 }
 

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/CBLockerService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/CBLockerService.kt
@@ -68,10 +68,21 @@ class CBLockerService {
     }
 
     fun putWithDeviceAddress(
-        context: Context, token: String, spacerId: String, address: String, callback: ICallback
+        context: Context,
+        token: String,
+        spacerId: String,
+        address: String,
+        isHttpSupported: Boolean,
+        isScanned: Boolean,
+        callback: ICallback
     ) {
         if (isProcessing.compareAndSet(false, true)) {
-            val cbLocker = CBLockerModel(spacerId, address)
+            val cbLocker = CBLockerModel(
+                spacerId,
+                address,
+                isHttpSupported = isHttpSupported,
+                isScanned = isScanned
+            )
             CBLockerScanConnectService().connectWithRetry(
                 CBLockerGattActionType.Put,
                 context,
@@ -85,10 +96,21 @@ class CBLockerService {
     }
 
     fun takeWithDeviceAddress(
-        context: Context, token: String, spacerId: String, address: String, callback: ICallback
+        context: Context,
+        token: String,
+        spacerId: String,
+        address: String,
+        isHttpSupported: Boolean,
+        isScanned: Boolean,
+        callback: ICallback
     ) {
         if (isProcessing.compareAndSet(false, true)) {
-            val cbLocker = CBLockerModel(spacerId, address)
+            val cbLocker = CBLockerModel(
+                spacerId,
+                address,
+                isHttpSupported = isHttpSupported,
+                isScanned = isScanned
+            )
             CBLockerScanConnectService().connectWithRetry(
                 CBLockerGattActionType.Take,
                 context,
@@ -101,9 +123,19 @@ class CBLockerService {
         }
     }
 
-    fun read(context: Context, spacerId: String, callback: IResultCallback<String>) {
+    fun checkDoorStatusAvailable(
+        context: Context,
+        token: String,
+        spacerId: String,
+        callback: IResultCallback<Boolean>
+    ) {
         if (isProcessing.compareAndSet(false, true)) {
-            CBLockerScanConnectService().read(context, spacerId, createCallback(callback))
+            CBLockerScanConnectService().checkDoorStatusAvailable(
+                context,
+                token,
+                spacerId,
+                createCallback(callback)
+            )
         }
     }
 

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattReadService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/gatt/CBLockerGattReadService.kt
@@ -15,7 +15,6 @@ open class CBLockerGattReadService {
     protected lateinit var cbLocker: CBLockerModel
     private lateinit var callback: IResultCallback<String>
     private var bluetoothGatt: BluetoothGatt? = null
-    private var isRetry: Boolean = false
     private var isCanceled = false
 
     protected val spacerId get() = cbLocker.spacerId
@@ -29,14 +28,12 @@ open class CBLockerGattReadService {
         context: Context,
         cbLocker: CBLockerModel,
         callback: IResultCallback<String>,
-        isRetry: Boolean
     ) {
         logd("connect: ${cbLocker.spacerId} ")
 
         this.context = context
         this.cbLocker = cbLocker
         this.callback = callback
-        this.isRetry = isRetry
 
         connectRemoteDevice()
     }

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/http/HttpLockerService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/http/HttpLockerService.kt
@@ -1,0 +1,29 @@
+package com.spacer.sdk.services.cbLocker.http
+
+import com.spacer.sdk.data.ICallback
+import com.spacer.sdk.data.api.APIHeader
+import com.spacer.sdk.data.api.api
+import com.spacer.sdk.data.api.reqData.http.HttpLockerReqData
+
+import com.spacer.sdk.data.extensions.RetrofitCallExtensions.enqueue
+
+class HttpLockerService {
+
+    fun put(token: String, spacerId: String, lat: Double, lng: Double, callback: ICallback) {
+        val params = HttpLockerReqData(spacerId, lat, lng)
+
+        api.httpLocker.put(APIHeader.createHeader(token), params).enqueue(callback)
+    }
+
+    fun take(token: String, spacerId: String, lat: Double, lng: Double, callback: ICallback) {
+        val params = HttpLockerReqData(spacerId, lat, lng)
+
+        api.httpLocker.take(APIHeader.createHeader(token), params).enqueue(callback)
+    }
+
+    fun openForMaintenance(token: String, spacerId: String, lat: Double, lng: Double, callback: ICallback) {
+        val params = HttpLockerReqData(spacerId, lat, lng)
+
+        api.httpLocker.openForMaintenance(APIHeader.createHeader(token), params).enqueue(callback)
+    }
+}

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/http/HttpLockerService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/http/HttpLockerService.kt
@@ -9,19 +9,19 @@ import com.spacer.sdk.data.extensions.RetrofitCallExtensions.enqueue
 
 class HttpLockerService {
 
-    fun put(token: String, spacerId: String, lat: Double, lng: Double, callback: ICallback) {
+    fun put(token: String, spacerId: String, lat: Double?, lng: Double?, callback: ICallback) {
         val params = HttpLockerReqData(spacerId, lat, lng)
 
         api.httpLocker.put(APIHeader.createHeader(token), params).enqueue(callback)
     }
 
-    fun take(token: String, spacerId: String, lat: Double, lng: Double, callback: ICallback) {
+    fun take(token: String, spacerId: String, lat: Double?, lng: Double?, callback: ICallback) {
         val params = HttpLockerReqData(spacerId, lat, lng)
 
         api.httpLocker.take(APIHeader.createHeader(token), params).enqueue(callback)
     }
 
-    fun openForMaintenance(token: String, spacerId: String, lat: Double, lng: Double, callback: ICallback) {
+    fun openForMaintenance(token: String, spacerId: String, lat: Double?, lng: Double?, callback: ICallback) {
         val params = HttpLockerReqData(spacerId, lat, lng)
 
         api.httpLocker.openForMaintenance(APIHeader.createHeader(token), params).enqueue(callback)

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
@@ -176,27 +176,24 @@ class CBLockerScanConnectService : CBLockerScanSingleService() {
         spacerId: String,
         callback: ICallback
     ) {
-
         val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
 
         @SuppressLint("MissingPermission") val myLocation =
             locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)
                 ?: locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER)
 
-        myLocation?.let {
-            val lat = it.latitude
-            val lng = it.longitude
-            when (type) {
-                CBLockerGattActionType.Put -> HttpLockerService().put(
-                    token, spacerId, lat, lng, callback
-                )
-                CBLockerGattActionType.Take -> HttpLockerService().take(
-                    token, spacerId, lat, lng, callback
-                )
-                CBLockerGattActionType.OpenForMaintenance -> HttpLockerService().openForMaintenance(
-                    token, spacerId, lat, lng, callback
-                )
-            }
+        val lat = myLocation?.latitude
+        val lng = myLocation?.longitude
+        when (type) {
+            CBLockerGattActionType.Put -> HttpLockerService().put(
+                token, spacerId, lat, lng, callback
+            )
+            CBLockerGattActionType.Take -> HttpLockerService().take(
+                token, spacerId, lat, lng, callback
+            )
+            CBLockerGattActionType.OpenForMaintenance -> HttpLockerService().openForMaintenance(
+                token, spacerId, lat, lng, callback
+            )
         }
     }
 

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
@@ -85,7 +85,7 @@ class CBLockerScanConnectService : CBLockerScanSingleService() {
             createCallBack(context, token, spacerId, object : IResultCallback<CBLockerModel> {
                 override fun onSuccess(result: CBLockerModel) {
                     if (!result.isScanned) {
-                        callback.onSuccess(result.doorStatus == CBLockerConst.AvailableDoorStatus)
+                        callback.onSuccess(result.isHttpSupported)
                         return
                     }
                     val readConnectCallback = createReadCallBack(result, callback)
@@ -248,7 +248,7 @@ class CBLockerScanConnectService : CBLockerScanSingleService() {
             }
 
             override fun onFailure(error: SPRError) {
-                callback.onSuccess(cbLocker.doorStatus == CBLockerConst.AvailableDoorStatus)
+                callback.onSuccess(cbLocker.isHttpSupported)
             }
         }
     }

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
@@ -113,7 +113,7 @@ class CBLockerScanConnectService : CBLockerScanSingleService() {
         val retryCallback = object : ICallback {
             override fun onSuccess() = callback.onSuccess()
             override fun onFailure(error: SPRError) {
-                if (cbLocker.isHttpSupported && cbLocker.status == CBLockerGattStatus.None && httpFallbackErrors.contains(
+                if (cbLocker.isHttpSupported && !cbLocker.hasBLERetried && httpFallbackErrors.contains(
                         error
                     ) && PermissionChecker.isLocationPermitted(context)
                 ) {
@@ -140,6 +140,7 @@ class CBLockerScanConnectService : CBLockerScanSingleService() {
         callback: IFailureCallback
     ) {
         if (retryNum <= CBLockerConst.MaxRetryNum) {
+            cbLocker.hasBLERetried = true
             executable.invoke()
         } else {
             cbLocker.reset()

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanConnectService.kt
@@ -108,28 +108,28 @@ class CBLockerScanConnectService : CBLockerScanSingleService() {
     ) {
         if (cbLocker.isHttpSupported && !cbLocker.isScanned && PermissionChecker.isLocationPermitted(context)) {
             execHttpLockerService(context, type, token, cbLocker.spacerId, callback)
-            return
-        }
-        val retryCallback = object : ICallback {
-            override fun onSuccess() = callback.onSuccess()
-            override fun onFailure(error: SPRError) {
-                if (cbLocker.isHttpSupported && !cbLocker.hasBLERetried && httpFallbackErrors.contains(
-                        error
-                    ) && PermissionChecker.isLocationPermitted(context)
-                ) {
-                    execHttpLockerService(context, type, token, cbLocker.spacerId, callback)
-                    return
-                }
-                retryOrFailure(
-                    error, {
-                        connectWithRetry(
-                            type, context, token, cbLocker, callback, retryNum + 1, true
+        } else {
+            val retryCallback = object : ICallback {
+                override fun onSuccess() = callback.onSuccess()
+                override fun onFailure(error: SPRError) {
+                    if (cbLocker.isHttpSupported && !cbLocker.hasBLERetried && httpFallbackErrors.contains(
+                            error
+                        ) && PermissionChecker.isLocationPermitted(context)
+                    ) {
+                        execHttpLockerService(context, type, token, cbLocker.spacerId, callback)
+                    } else {
+                        retryOrFailure(
+                            error, {
+                                connectWithRetry(
+                                    type, context, token, cbLocker, callback, retryNum + 1, true
+                                )
+                            }, retryNum + 1, cbLocker, callback
                         )
-                    }, retryNum + 1, cbLocker, callback
-                )
+                    }
+                }
             }
+            createCBLockerGattServiceWithConnect(type, context, token, cbLocker, retryCallback, isRetry)
         }
-        createCBLockerGattServiceWithConnect(type, context, token, cbLocker, retryCallback, isRetry)
     }
 
     fun retryOrFailure(

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanService.kt
@@ -144,6 +144,7 @@ open class CBLockerScanService {
                 result.forEach { sprLocker ->
                     cbLockerMap[sprLocker.id]?.let { cbLocker ->
                         sprLocker.address = cbLocker.address
+                        sprLocker.isScanned = spacerIds.contains(sprLocker.id)
                     }
                 }
                 callback.onSuccess(result)
@@ -154,6 +155,25 @@ open class CBLockerScanService {
             }
         }
         SPRLockerService().getLockers(token, spacerIds, getLockersCallback)
+    }
+
+    protected fun CBLockerModel.parse(
+        token: String, isScanned: Boolean, callback: IResultCallback<SPRLockerModel>
+    ) {
+        val spacerId = this.spacerId
+        val address = this.address
+        val getLockersCallback = object : IResultCallback<SPRLockerModel> {
+            override fun onSuccess(result: SPRLockerModel) {
+                result.address = address
+                result.isScanned = isScanned
+                callback.onSuccess(result)
+            }
+
+            override fun onFailure(error: SPRError) {
+                callback.onFailure(error)
+            }
+        }
+        SPRLockerService().getLocker(token, spacerId, getLockersCallback)
     }
 
     companion object {

--- a/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanSingleService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/cbLocker/scan/CBLockerScanSingleService.kt
@@ -2,6 +2,7 @@ package com.spacer.sdk.services.cbLocker.scan
 
 import android.content.Context
 import com.spacer.sdk.data.IResultCallback
+import com.spacer.sdk.data.PermissionChecker
 import com.spacer.sdk.data.SPRError
 import com.spacer.sdk.models.cbLocker.CBLockerModel
 import com.spacer.sdk.models.sprLocker.SPRLockerModel
@@ -38,7 +39,7 @@ open class CBLockerScanSingleService : CBLockerScanService() {
                     false,
                     object : IResultCallback<SPRLockerModel> {
                         override fun onSuccess(result: SPRLockerModel) {
-                            if (result.isHttpSupported) {
+                            if (result.isHttpSupported && PermissionChecker.isLocationPermitted(context)) {
                                 callback.onSuccess(result)
                             } else {
                                 callback.onFailure(error)

--- a/sdk/src/main/java/com/spacer/sdk/services/sprLocker/SPRLockerService.kt
+++ b/sdk/src/main/java/com/spacer/sdk/services/sprLocker/SPRLockerService.kt
@@ -3,23 +3,30 @@ package com.spacer.sdk.services.sprLocker
 import com.spacer.sdk.data.IResultCallback
 import com.spacer.sdk.data.api.APIHeader
 import com.spacer.sdk.data.api.api
-import com.spacer.sdk.data.api.reqData.sprLocker.SPRLockerGetReqData
+import com.spacer.sdk.data.api.reqData.sprLocker.SPRLockerListReqData
 import com.spacer.sdk.data.api.reqData.sprLocker.SPRLockerUnitGetReqData
 import com.spacer.sdk.data.extensions.RetrofitCallExtensions.enqueue
-import com.spacer.sdk.models.sprLocker.SPRLockerListMapper
-import com.spacer.sdk.models.sprLocker.SPRLockerModel
-import com.spacer.sdk.models.sprLocker.SPRLockerUnitGetReqDataMapper
-import com.spacer.sdk.models.sprLocker.SPRLockerUnitModel
+import com.spacer.sdk.models.sprLocker.*
 
 class SPRLockerService {
-    fun getLockers(token: String, spacerIds: List<String>, callback: IResultCallback<List<SPRLockerModel>>) {
-        val params = SPRLockerGetReqData(spacerIds)
+    fun getLockers(
+        token: String, spacerIds: List<String>, callback: IResultCallback<List<SPRLockerModel>>
+    ) {
+        val params = SPRLockerListReqData(spacerIds)
         val mapper = SPRLockerListMapper()
 
         api.sprLocker.getLockers(APIHeader.createHeader(token), params).enqueue(callback, mapper)
     }
 
-    fun getUnits(token: String, unitIds: List<String>, callback: IResultCallback<List<SPRLockerUnitModel>>) {
+    fun getLocker(token: String, spacerId: String, callback: IResultCallback<SPRLockerModel>) {
+        val mapper = SPRLockerGetMapper()
+
+        api.sprLocker.getLocker(APIHeader.createHeader(token), spacerId).enqueue(callback, mapper)
+    }
+
+    fun getUnits(
+        token: String, unitIds: List<String>, callback: IResultCallback<List<SPRLockerUnitModel>>
+    ) {
         val params = SPRLockerUnitGetReqData(unitIds)
         val mapper = SPRLockerUnitGetReqDataMapper()
 

--- a/sdk/src/main/java/com/spacer/sdk/values/cbLocker/CBLockerConst.kt
+++ b/sdk/src/main/java/com/spacer/sdk/values/cbLocker/CBLockerConst.kt
@@ -12,7 +12,6 @@ class CBLockerConst {
         const val ReadTimeoutSeconds: Long = 5000
         const val WriteTimeoutSeconds: Long = 5000
         const val DuringTimeoutSeconds: Long = 60000
-        const val AvailableDoorStatus = "closed"
 
         val ScanMills = SPR.config.scanMills
         val MaxRetryNum = SPR.config.maxRetryNum

--- a/sdk/src/main/java/com/spacer/sdk/values/cbLocker/CBLockerConst.kt
+++ b/sdk/src/main/java/com/spacer/sdk/values/cbLocker/CBLockerConst.kt
@@ -7,18 +7,19 @@ class CBLockerConst {
     companion object {
         const val DEVICE_PUT_PREFIX = "543214723567xxxrw"
         const val DEVICE_TAKE_PREFIX = "543214723567xxxw"
-        const val StartTimeoutSeconds: Long  = 5000
-        const val DiscoverTimeoutSeconds: Long  = 5000
-        const val ReadTimeoutSeconds: Long  = 5000
-        const val WriteTimeoutSeconds: Long  = 5000
-        const val DuringTimeoutSeconds: Long  = 60000
+        const val StartTimeoutSeconds: Long = 5000
+        const val DiscoverTimeoutSeconds: Long = 5000
+        const val ReadTimeoutSeconds: Long = 5000
+        const val WriteTimeoutSeconds: Long = 5000
+        const val DuringTimeoutSeconds: Long = 60000
+        const val AvailableDoorStatus = "closed"
 
         val ScanMills = SPR.config.scanMills
         val MaxRetryNum = SPR.config.maxRetryNum
         val DeviceServiceUUID = UUID.fromString("0000ff10-0000-1000-8000-00805f9b34fb")!!
         val DeviceCharacteristicUUID = UUID.fromString("0000ff11-0000-1000-8000-00805f9b34fb")!!
         val UsingReadData: List<String> = listOf("using")
-        val WriteReadData: List<String> = listOf("rwsuccess", "wsuccess")
+        private val WriteReadData: List<String> = listOf("rwsuccess", "wsuccess")
         val UsingOrWriteReadData: List<String> = UsingReadData + WriteReadData
     }
 }


### PR DESCRIPTION
## :ticket: チケット
APL-1002 [Android SDK] アプリ接続の冗長化対応
https://spacer-inc.backlog.com/view/APL-1002

## :memo: 概要
施錠開錠について、BLEで失敗した場合にHTTPでの施錠開錠を行うよう対応

## :+1: 対応内容
概要と同様

## :white_check_mark: 動作確認
施錠開錠について
・BLEコネクトに失敗した場合にHTTPでの施錠開錠リクエストを行うこと
・スキャンに失敗している場合は、BLEを利用せずHTTPでの施錠開錠リクエストを行うこと
・施錠開錠のスキャン時にreadAPIを叩き、http接続可能かの情報を取得できること